### PR TITLE
FIXED: Modal windows render behind content on Safari

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -164,16 +164,8 @@ th {
   color: #dfa53d;
 }
 
-
-.parameters-form {
-  margin-top: 20px;
-  position: relative;
-  z-index: 1000;
-}
-
 .dropdown-section {
   margin-bottom: 20px;
-
 }
 
 .dropdown-section button {

--- a/frontend/src/components/ChartView.css
+++ b/frontend/src/components/ChartView.css
@@ -106,13 +106,6 @@
   z-index: 1000;
 }
 
-.modal-content {
-  background: white;
-  padding: 20px;
-  border-radius: 10px;
-  text-align: center;
-}
-
 .save-button, .cancel-button {
   margin: 10px;
   padding: 10px;

--- a/frontend/src/components/Interventions.js
+++ b/frontend/src/components/Interventions.js
@@ -3,6 +3,7 @@ import Antivirals from './Antivirals';
 import Vaccine from './Vaccine';
 import NonPharmaceutical from './NonPharmaceutical';
 import './SetParametersDropdown.css';
+import { createPortal } from 'react-dom';
 
 const Interventions = () => {
   const [showDropdown, setShowDropdown] = useState(false);
@@ -41,30 +42,45 @@ const Interventions = () => {
         </div>
       )}
       {isAntiviralsOpen && (
-        <div className="modal-overlay" onClick={closeAntivirals}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <span className="modal-close" onClick={closeAntivirals}>&times;</span>
-            <h2>Antiviral Parameters and Stockpiles</h2>
-            <Antivirals onSubmit={(eff, wf, avs) => { console.log("Eff: ", eff, " WF: ", wf, " AVS: ", avs); closeAntivirals(); }} />
-          </div>
+        <div>
+          {createPortal(
+            <div className="modal-overlay" onClick={closeAntivirals}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={closeAntivirals}>&times;</span>
+                <h2>Antiviral Parameters and Stockpiles</h2>
+                <Antivirals onSubmit={(eff, wf, avs) => { console.log("Eff: ", eff, " WF: ", wf, " AVS: ", avs); closeAntivirals(); }} />
+              </div>
+            </div>,
+            document.body
+          )}
         </div>
       )}
       {isVaccineOpen && (
-        <div className="modal-overlay" onClick={closeVaccine}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <span className="modal-close" onClick={closeVaccine}>&times;</span>
-            <h2>Vaccine Stockpile</h2>
-            <Vaccine onSubmit={(ve, va, vwf, vs, vsl) => { console.log("Eff:", ve, " Adh: ", va, " WF: ", vwf, " Strat: ", vs, " VS: ", vsl); closeVaccine(); }} />
-          </div>
+        <div>
+          {createPortal(
+            <div className="modal-overlay" onClick={closeVaccine}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={closeVaccine}>&times;</span>
+                <h2>Vaccine Stockpile</h2>
+                <Vaccine onSubmit={(ve, va, vwf, vs, vsl) => { console.log("Eff:", ve, " Adh: ", va, " WF: ", vwf, " Strat: ", vs, " VS: ", vsl); closeVaccine(); }} />
+              </div>
+            </div>,
+            document.body
+          )}
         </div>
       )}
       {isNonPharmaceuticalOpen && (
-        <div className="modal-overlay" onClick={closeNonPharmaceutical}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <span className="modal-close" onClick={closeNonPharmaceutical}>&times;</span>
-            <h2>Non-Pharmaceutical Interventions</h2>
-            <NonPharmaceutical onSubmit={(npil) => { console.log('Non-Pharmaceutical:', npil); closeNonPharmaceutical(); }} />
-          </div>
+        <div>
+          {createPortal(
+            <div className="modal-overlay" onClick={closeNonPharmaceutical}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={closeNonPharmaceutical}>&times;</span>
+                <h2>Non-Pharmaceutical Interventions</h2>
+                <NonPharmaceutical onSubmit={(npil) => { console.log('Non-Pharmaceutical:', npil); closeNonPharmaceutical(); }} />
+              </div>
+            </div>,
+            document.body
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/SetParametersDropdown.css
+++ b/frontend/src/components/SetParametersDropdown.css
@@ -185,6 +185,8 @@
   transform: translate(-50%, -50%);
   z-index: 4; /* Ensure it is above the overlay */
   font-size: large;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 .modal-close {

--- a/frontend/src/components/SetParametersDropdown.js
+++ b/frontend/src/components/SetParametersDropdown.js
@@ -38,7 +38,7 @@ const SetParametersDropdown = ({ counties, onSave }) => {
         </div>
       )}
       {isSetManuallyOpen && (
-        <div className="modal-overlay" onClick={closeSetManually}>
+        <div className="TESTNONE" onClick={closeSetManually}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <span className="modal-close" onClick={closeSetManually}>×</span>
             <h2>Disease Parameters</h2>
@@ -47,7 +47,7 @@ const SetParametersDropdown = ({ counties, onSave }) => {
         </div>
       )}
       {isInitialCasesOpen && (
-        <div className="modal-overlay" onClick={closeInitialCases}>
+        <div className="TESTNONE" onClick={closeInitialCases}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <span className="modal-close" onClick={closeInitialCases}>×</span>
             <h2>Add Initial Cases</h2>
@@ -60,3 +60,5 @@ const SetParametersDropdown = ({ counties, onSave }) => {
 };
 
 export default SetParametersDropdown;
+
+// FIXME: className="modal-overlay" changed to "TESTNONE" for debugging; restore changes before merging!

--- a/frontend/src/components/SetParametersDropdown.js
+++ b/frontend/src/components/SetParametersDropdown.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import AddInitialCases from './AddInitialCases';
 import SetManually from './SetManually';
 import './SetParametersDropdown.css';
+import { createPortal } from 'react-dom';
 
 const SetParametersDropdown = ({ counties, onSave }) => {
   const [showDropdown, setShowDropdown] = useState(false);
@@ -38,16 +39,22 @@ const SetParametersDropdown = ({ counties, onSave }) => {
         </div>
       )}
       {isSetManuallyOpen && (
-        <div className="TESTNONE" onClick={closeSetManually}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <span className="modal-close" onClick={closeSetManually}>×</span>
-            <h2>Disease Parameters</h2>
-            <SetManually onClose={closeSetManually} onSubmit={(data) => { console.log('Set Manually:', data); handleSave(); }} />
-          </div>
+        <div>
+          {/* Appending modal window to document.body prevents a rendering bug on Safari */}
+          {createPortal(
+            <div className="modal-overlay" onClick={closeSetManually}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={closeSetManually}>×</span>
+                <h2>Disease Parameters</h2>
+                <SetManually onClose={closeSetManually} onSubmit={(data) => { console.log('Set Manually:', data); handleSave(); }} />
+              </div>
+            </div>,
+            document.body
+          )}
         </div>
       )}
       {isInitialCasesOpen && (
-        <div className="TESTNONE" onClick={closeInitialCases}>
+        <div className="modal-overlay" onClick={closeInitialCases}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <span className="modal-close" onClick={closeInitialCases}>×</span>
             <h2>Add Initial Cases</h2>

--- a/frontend/src/components/SetParametersDropdown.js
+++ b/frontend/src/components/SetParametersDropdown.js
@@ -54,12 +54,17 @@ const SetParametersDropdown = ({ counties, onSave }) => {
         </div>
       )}
       {isInitialCasesOpen && (
-        <div className="modal-overlay" onClick={closeInitialCases}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <span className="modal-close" onClick={closeInitialCases}>×</span>
-            <h2>Add Initial Cases</h2>
-            <AddInitialCases onClose={closeInitialCases} counties={counties} onSubmit={(data) => { console.log('Initial Cases:', data); handleSave(); }} />
-          </div>
+        <div>
+          {createPortal(
+            <div className="modal-overlay" onClick={closeInitialCases}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={closeInitialCases}>×</span>
+                <h2>Add Initial Cases</h2>
+                <AddInitialCases onClose={closeInitialCases} counties={counties} onSubmit={(data) => { console.log('Initial Cases:', data); handleSave(); }} />
+              </div>
+            </div>,
+            document.body
+          )}
         </div>
       )}
     </div>
@@ -67,5 +72,3 @@ const SetParametersDropdown = ({ counties, onSave }) => {
 };
 
 export default SetParametersDropdown;
-
-// FIXME: className="modal-overlay" changed to "TESTNONE" for debugging; restore changes before merging!

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,17 +49,16 @@ code {
   z-index: 20000; /* Ensure the z-index is high enough */
 }
 
-.modal-content {
+/*.modal-content {
   background-color: white;
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  max-width: 500px;
-  width: 100%;
-  position: relative;
+  max-width: 600px;
+  width: 90%;
   z-index: 10001;
   overflow-y: auto;
-}
+}*/
 
 .modal-close {
   position: absolute;


### PR DESCRIPTION
Modal windows would render behind all other content on Safari, inaccessible to the user.
Appending modal windows directly to the document body with React Portals resolved the issue while preserving expected functionality on Chrome/Firefox.