### PR TITLE
New simulation button

### DIFF
--- a/backend/pet/pes_task.py
+++ b/backend/pet/pes_task.py
@@ -25,16 +25,20 @@ def return_valid_input(input):
     try: phas = json.loads(input['phas'])
     except TypeError: phas = None
     
-    try: avs = json.loads(input['phas'])
+    try: avs = json.loads(input['antiviral_stockpile'])
     except TypeError: avs = None
     
-    try: va = json.loads(input['phas'])
+    try: va = json.loads(input['vaccine_adherence'])
     except TypeError: va = None
+    if va is not None:
+        va = [va] * 5
     
-    try: ve = json.loads(input['phas'])
+    try: ve = json.loads(input['vaccine_effectiveness'])
     except TypeError: ve = None
+    if ve is not None:
+        ve = [ve] * 5
     
-    try: vs = json.loads(input['phas'])
+    try: vs = json.loads(input['vaccine_stockpile'])
     except TypeError: vs = None
     
     input_file = {

--- a/frontend/NewSimulationButton.js
+++ b/frontend/NewSimulationButton.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// create a button that spawns a modal window
+const NewSimulationButton = ({}) => {
+  const [resetModalActive, setResetModalActive] = useState(false);
+
+  const toggleResetModal = () => setResetModalActive(!resetModalActive);
+
+  return (
+    <div className="newsim-btn-container">
+      <button className="reset-button" onClick={toggleResetModal}>New Simulation</button>
+      {resetModalActive && (
+      <div>
+          {createPortal(
+            <div className="modal-overlay" onClick={toggleResetModal}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={toggleResetModal}>×</span>
+              </div>
+            </div>,
+            document.body
+          )}
+      </div>
+      )}
+    </div>
+  )
+};
+
+export default NewSimulationButton;

--- a/frontend/src/components/AddInitialCases.css
+++ b/frontend/src/components/AddInitialCases.css
@@ -38,10 +38,6 @@ button {
   cursor: pointer;
 }
 
-button:hover {
-  background-color: #f7b13c;
-}
-
 /* Tooltip Section -- In the Modal */
 .tooltip {
   display: inline-block;

--- a/frontend/src/components/HomeView.js
+++ b/frontend/src/components/HomeView.js
@@ -5,6 +5,7 @@ import DeceasedLineChart from './DeceasedLineChart';
 import StateCountyDropdowns from './StateCountyDropdown';
 import CountyPercentageTable from './CountyPercentageTable';
 import InitialMapPercent from './InitialMapPercent';
+import NewSimulationButton from './NewSimulationButton';
 import SetParametersDropdown from './SetParametersDropdown';
 import Interventions from './Interventions';
 import SavedParameters from './SavedParameters';
@@ -199,6 +200,7 @@ const HomeView = () => {
   return (
     <div>
       <div className="left-panel">
+        <NewSimulationButton />
         <SetParametersDropdown counties={texasCounties} onSave={handleSave} />
         <div className="interventions-container">
           <Interventions />

--- a/frontend/src/components/HomeView.js
+++ b/frontend/src/components/HomeView.js
@@ -60,7 +60,16 @@ const HomeView = () => {
       chi: localStorage.getItem('chi'),
       rho: localStorage.getItem('rho'),
       nu: localStorage.getItem('nu'),
-      initial_infected: localStorage.getItem('initial_infected')
+      initial_infected: localStorage.getItem('initial_infected'),
+      phas: localStorage.getItem('nonpharma_list'),
+      antiviral_effectiveness: localStorage.getItem('antiviral_effectiveness'),
+      antiviral_wastage_factor: localStorage.getItem('antiviral_wastage_factor'),
+      antiviral_stockpile: localStorage.getItem('antiviral_stockpile'),
+      vaccine_effectiveness: localStorage.getItem('vaccine_effectiveness'),
+      vaccine_adherence: localStorage.getItem('vaccine_adherence'),
+      vaccine_wastage_factor: localStorage.getItem('vaccine_wastage_factor'),
+      vaccine_pro_rata: localStorage.getItem('vaccine_strategy'),
+      vaccine_stockpile: localStorage.getItem('vaccine_stockpile'),
     })
     .then(response => {
       console.log('Disease parameters updated successfully:', response.data['id']);

--- a/frontend/src/components/NewSimulationButton.js
+++ b/frontend/src/components/NewSimulationButton.js
@@ -9,6 +9,16 @@ const NewSimulationButton = () => {
 
   const toggleModal = () => setIsModalOpen(!isModalOpen);
 
+  const handleReset = () => {
+    // clear parameters from local storage
+    console.log("clearing local storage");
+    localStorage.clear();
+    // this is where we'll pass the GET request
+    console.log("GETting reset request to Django server")
+    // refresh the page
+    location.reload();
+  }
+
   return (
     <div className="reset-container">
       <button className="reset-button" onClick={toggleModal}>New Simulation</button>
@@ -18,7 +28,12 @@ const NewSimulationButton = () => {
             <div className="modal-overlay" onClick={toggleModal}>
               <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <span className="modal-close" onClick={toggleModal}>×</span>
-                <NewSimulationModal />
+                <h2>New Simulation</h2>
+                <p>Starting a new simulation will clear all previous parameters and erase previous simulation data. Do you wish to continue?</p>
+                <div className="confirmation-buttons">
+                  <button className="cancel-reset-button" onClick={toggleModal}>Cancel</button>
+                  <button className="confirm-reset-button" onClick={handleReset}>Reset</button>
+                </div>
               </div>
             </div>,
             document.body

--- a/frontend/src/components/NewSimulationButton.js
+++ b/frontend/src/components/NewSimulationButton.js
@@ -28,7 +28,7 @@ const NewSimulationButton = () => {
             <div className="modal-overlay" onClick={toggleModal}>
               <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <span className="modal-close" onClick={toggleModal}>×</span>
-                <h2>New Simulation</h2>
+                <h2>Warning!</h2>
                 <p>Starting a new simulation will clear all previous parameters and erase previous simulation data. Do you wish to continue?</p>
                 <div className="confirmation-buttons">
                   <button className="cancel-reset-button" onClick={toggleModal}>Cancel</button>

--- a/frontend/src/components/NewSimulationButton.js
+++ b/frontend/src/components/NewSimulationButton.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import NewSimulationModal from './NewSimulationModal.js';
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// create a button that spawns a modal window
+const NewSimulationButton = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const toggleModal = () => setIsModalOpen(!isModalOpen);
+
+  return (
+    <div className="reset-container">
+      <button className="reset-button" onClick={toggleModal}>New Simulation</button>
+      {isModalOpen && (
+        <div>
+          {createPortal(
+            <div className="modal-overlay" onClick={toggleModal}>
+              <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <span className="modal-close" onClick={toggleModal}>×</span>
+                <NewSimulationModal />
+              </div>
+            </div>,
+            document.body
+          )}
+        </div>
+      )}
+    </div>
+  )
+};
+
+export default NewSimulationButton;
+

--- a/frontend/src/components/NewSimulationButton.js
+++ b/frontend/src/components/NewSimulationButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import NewSimulationModal from './NewSimulationModal.js';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
+import axios from 'axios';
 
 // create a button that spawns a modal window
 const NewSimulationButton = () => {
@@ -9,13 +10,12 @@ const NewSimulationButton = () => {
 
   const toggleModal = () => setIsModalOpen(!isModalOpen);
 
-  const handleReset = () => {
-    // clear parameters from local storage
+  const handleReset = async () => {
     console.log("clearing local storage");
     localStorage.clear();
-    // this is where we'll pass the GET request
     console.log("GETting reset request to Django server")
-    // refresh the page
+    // TODO: it might be prudent to wait for a 200 before refreshing the page
+    const response = await axios.get(`http://localhost:8000/api/reset`);
     location.reload();
   }
 
@@ -28,8 +28,8 @@ const NewSimulationButton = () => {
             <div className="modal-overlay" onClick={toggleModal}>
               <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <span className="modal-close" onClick={toggleModal}>×</span>
-                <h2>Warning!</h2>
-                <p>Starting a new simulation will clear all previous parameters and erase previous simulation data. Do you wish to continue?</p>
+                <h2 className="reset-warning">Warning!</h2>
+                <p>Starting a new simulation will clear all previous parameters and erase previous simulation data.</p>
                 <div className="confirmation-buttons">
                   <button className="cancel-reset-button" onClick={toggleModal}>Cancel</button>
                   <button className="confirm-reset-button" onClick={handleReset}>Reset</button>

--- a/frontend/src/components/NewSimulationModal.js
+++ b/frontend/src/components/NewSimulationModal.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const NewSimulationModal = () => {
+  return (
+    <div className="reset-dialog">
+      <h2>New Simulation</h2>
+      <p>Starting a new simulation will clear all previous parameters and erase previous simulation data. Do you wish to continue?</p>
+      <div clasName="confirmation-buttons">
+        <button className="cancel-reset-button">Cancel</button>
+        <button className="confirm-reset-button">Reset</button>
+      </div>
+    </div>
+  )
+};
+
+export default NewSimulationModal;

--- a/frontend/src/components/NewSimulationModal.js
+++ b/frontend/src/components/NewSimulationModal.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
-const NewSimulationModal = () => {
+const NewSimulationModal = ({isModalOpen, setIsModalOpen}) => {
   return (
     <div className="reset-dialog">
       <h2>New Simulation</h2>
       <p>Starting a new simulation will clear all previous parameters and erase previous simulation data. Do you wish to continue?</p>
       <div clasName="confirmation-buttons">
-        <button className="cancel-reset-button">Cancel</button>
+        <button className="cancel-reset-button" onClick={setIsModalOpen(false)}>Cancel</button>
         <button className="confirm-reset-button">Reset</button>
       </div>
     </div>

--- a/frontend/src/components/Vaccine.js
+++ b/frontend/src/components/Vaccine.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import './Parameters.css'
 import toggletip from  "./images/toggletip.svg";
 import './AddInitialCases.css';
 
@@ -124,8 +125,8 @@ const Vaccine = ({ onSubmit }) => {
                   type="radio"
                   id="prorataAll"
                   name="vaccineStrategy"
-                  value="all"
-                  checked={vaccineStrategy === "all"}
+                  value="pro_rata"
+                  checked={vaccineStrategy === "pro_rata"}
                   onChange={e => setVaccineStrategy(e.target.value)}
                   required
                 />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,9 +140,9 @@ code {
 
 .reset-button {
   width: 100%; /* Set a fixed width that matches the dropdown menu width */
-  padding: 15px 16px; /* Ensure padding matches the dropdown items */
-  background-color: #f7b13c; /* Example background color */
-  color: black;
+  /*padding: 15px 16px;*/
+  background-color: #fb4934;
+  color: white;
   font-size: medium;
   font-weight: bold;
   border: none;
@@ -163,7 +163,7 @@ code {
   cursor: pointer;
   margin: auto;
   float: left;
-  padding: 1em 2em 1em 2em;
+  padding: 1vw 2vw 1vw 2vw;
   font-size: large;
   font-weight: bold;
   border: none;
@@ -175,7 +175,7 @@ code {
   cursor: pointer;
   margin: auto;
   float: right;
-  padding: 1em 2em 1em 2em;
+  padding: 1vw 2vw 1vw 2vw;
   font-size: large;
   font-weight: bold;
   border: none;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,3 +138,53 @@ code {
   font-size: 16px;
 }
 
+.reset-button {
+  width: 100%; /* Set a fixed width that matches the dropdown menu width */
+  padding: 15px 16px; /* Ensure padding matches the dropdown items */
+  background-color: #f7b13c; /* Example background color */
+  color: black;
+  font-size: medium;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center; /* Center text and arrow horizontally */
+  align-items: center; /* Center text and arrow vertically */
+  position: relative;
+  box-sizing: border-box; /* Ensure padding and borders are included in the width */
+}
+
+.confirmation-buttons {
+  margin-top: 10%;
+}
+
+.cancel-reset-button {
+  cursor: pointer;
+  margin: auto;
+  float: left;
+  padding: 1em 2em 1em 2em;
+  font-size: large;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  background-color: #f7b13c;
+}
+
+.confirm-reset-button {
+  cursor: pointer;
+  margin: auto;
+  float: right;
+  padding: 1em 2em 1em 2em;
+  font-size: large;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  background-color: #fb4934;
+  color: white;
+  transition: 0.2s;
+}
+
+.confirm-reset-button:hover {
+  background-color: #cc241d;
+}


### PR DESCRIPTION
Added a button that clears local storage, resets backend /api/output, and refreshes the page.
I put stylings for the new button and modal in `index.css` to avoid writing merge conflicts with Magret's UI changes. We can drag and drop the CSS elsewhere when needed