### PR TITLE
Leaflet attribution remove

### DIFF
--- a/frontend/src/components/HomeView.js
+++ b/frontend/src/components/HomeView.js
@@ -64,7 +64,7 @@ const HomeView = () => {
 
 
   const handleDayChange = (index) => {
-    debugger;
+    // debugger;
     console.log(`Day changed to: ${index}`);
     setCurrentIndex(index);
   };
@@ -131,13 +131,13 @@ const HomeView = () => {
 
 
   useEffect(() => {
-    debugger;
+    // debugger;
     const nextAvailable = eventData.length;
     console.log("Length test", eventData.length);
     console.log("next available", nextAvailable)
 
     const fetchData = async (requestedIndex) => {
-      debugger;
+      // debugger;
       try {
         const response = await axios.get(`http://localhost:8000/api/output/${requestedIndex}`);
 
@@ -207,7 +207,7 @@ const HomeView = () => {
       }
     };
 
-    debugger;
+    // debugger;
 
     if (isRunning) {
       setTimeout(() => {
@@ -227,8 +227,8 @@ const HomeView = () => {
   return (
 
     <div >
-      <div class="row">
-        <div class="col-lg-2">
+      <div className="row">
+        <div className="col-lg-2">
           <div className='left-panel'>
             <SetParametersDropdown
               counties={texasCounties}
@@ -247,7 +247,7 @@ const HomeView = () => {
         </div>
 
         {/* Middlle Panel - Infected Map (Count and Percentage) and Line Chart */}
-        <div class="col-lg-7">
+        <div className="col-lg-7">
 
           <div className='top-middle-panel'>
             <div className="radio-buttons-container">
@@ -287,7 +287,7 @@ const HomeView = () => {
 
 
         {/* Right Panel - Infected Decease Table */}
-        <div class="col-lg-3">
+        <div className="col-lg-3">
           <div className='right-panel'>
             {viewType === 'percent' ? (
               <InfectedDeceasedTableMergedPercent currentIndex={currentIndex} eventData={eventData} />

--- a/frontend/src/components/InfectedMap.js
+++ b/frontend/src/components/InfectedMap.js
@@ -164,6 +164,7 @@ const InfectedMap = ({ eventData, currentIndex}) => {
         zoomSnap={0.2}
         zoom={5.4}
         style={{ height: '35em', backgroundColor: 'transparent'}}
+        attributionControl={false}
         whenCreated={mapInstance => { mapRef.current = mapInstance; }}
       >
         <GeoJSON

--- a/frontend/src/components/InfectedMapPercent.js
+++ b/frontend/src/components/InfectedMapPercent.js
@@ -7,18 +7,7 @@ import './Legend.css'; // Ensure you have a CSS file for styling
 import '../fonts/fonts.css'
 
 // Function to determine color based on infected count
-// TODO: is it weird to have different number of buckets between count/percent?
 const getColor = (infectedPercent) => {
-  // return infectedPercent > 90 ? "#3B1253" :
-  //        infectedPercent > 80 ? "#6D1F6F" :
-  //        infectedPercent > 70 ? "#8F286A" :
-  //        infectedPercent > 60 ? "#AA3760" :
-  //        infectedPercent > 50 ? "#C1444B" :
-  //        infectedPercent > 40 ? "#D4624D" :
-  //        infectedPercent > 30 ? "#E1865C" :
-  //        infectedPercent > 20 ? "#EAAE70" :
-  //        infectedPercent > 10 ? "#F2D789" :
-  //                               "#FFEDA0"
   return infectedPercent >= 40 ? "#BD0026" :
          infectedPercent >= 30 ? "#E31A1B" :
          infectedPercent >= 20 ? "#FC4F2A" :
@@ -93,6 +82,8 @@ const Legend = () => {
 const InfectedMapPercent = ({ eventData, currentIndex }) => {
   const [countyData, setCountyData] = useState([]);
   const mapRef = useRef();
+
+  L.control.attribution.remove();
 
   useEffect(() => {
     const texasCounties = parseTexasOutline(texasOutline);

--- a/frontend/src/components/InfectedMapPercent.js
+++ b/frontend/src/components/InfectedMapPercent.js
@@ -148,6 +148,7 @@ const onEachCounty = (feature, layer) => {
         zoomSnap={0.2}
         zoom={5.4}
         style={{ height: '35em', backgroundColor: 'transparent'}}
+        attributionControl={false}
         whenCreated={mapInstance => {mapRef.current=mapInstance; }}
       >
         <GeoJSON

--- a/frontend/src/components/InfectedMapPercent.js
+++ b/frontend/src/components/InfectedMapPercent.js
@@ -83,8 +83,6 @@ const InfectedMapPercent = ({ eventData, currentIndex }) => {
   const [countyData, setCountyData] = useState([]);
   const mapRef = useRef();
 
-  L.control.attribution.remove();
-
   useEffect(() => {
     const texasCounties = parseTexasOutline(texasOutline);
     if (eventData && eventData.length > 0 && typeof currentIndex !== "undefined") {


### PR DESCRIPTION
Removed the link in the bottom-right corner of our maps that interrupted the simulation and redirected users to Leaflet website/docs