### PR TITLE
Page leave warning

### DIFF
--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './Header.css';
 import epiengage_logo_darkblue from './epiengage_logo_darkblue.jpg';
 import GalleryView from '../GalleryView';
@@ -13,6 +13,19 @@ import Navbar from 'react-bootstrap/Navbar';
 
 const Header = ({ currentIndex, setCurrentIndex }) => {
   const [activeTab, setActiveTab] = useState('home');
+
+  // add an EventListener that warns the user before leaving the page and wiping parameters/simulation
+  useEffect(() => {
+    window.addEventListener('beforeunload', alertUser);
+    return () => {
+      window.removeEventListener('beforeunload', alertUser);
+    }
+  }, [])
+
+  const alertUser = e => {
+    e.preventDefault();
+    e.returnValue = '';
+  }
 
   const renderTabContent = () => {
     switch (activeTab) {

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -5,6 +5,7 @@ import GalleryView from '../GalleryView';
 import UserGuideView from '../UserGuideView';
 import HomeView from '../HomeView';
 import ChartView from '../ChartView';
+import axios from 'axios';
 
 import Container from 'react-bootstrap/Container';
 import Nav from 'react-bootstrap/Nav';
@@ -17,14 +18,22 @@ const Header = ({ currentIndex, setCurrentIndex }) => {
   // add an EventListener that warns the user before leaving the page and wiping parameters/simulation
   useEffect(() => {
     window.addEventListener('beforeunload', alertUser);
+    window.addEventListener('unload', handlePageLeave);
     return () => {
       window.removeEventListener('beforeunload', alertUser);
+      window.removeEventListener('unload', handlePageLeave);
+      handlePageLeave();
     }
   }, [])
 
   const alertUser = e => {
     e.preventDefault();
     e.returnValue = '';
+  }
+
+  const handlePageLeave = async () => {
+    localStorage.clear();
+    await axios.get('http://localhost:8000/api/reset');
   }
 
   const renderTabContent = () => {


### PR DESCRIPTION
Displays a warning before unloading the page, usually either by going back in history, reloading, or a redirect. The user can cancel and stay on the page. If the user unloads, localStorage is cleared and a reset request is sent to django